### PR TITLE
Skip first value in predicted_glucose

### DIFF
--- a/chart.py
+++ b/chart.py
@@ -39,10 +39,8 @@ def glucose_line_chart(recent_glucose, predicted_glucose, targets):
                 entry.get('sgv') or entry.get('amount') or entry['glucose'],
                 targets
             ))
-
-        iter_predicted_glucose = iter(predicted_glucose)
-        next(iter_predicted_glucose)    
-        for entry in iter_predicted_glucose:
+  
+        for entry in predicted_glucose[1:]:
             rows.append(glucose_row(entry['date'], entry['glucose'], targets, 'Predicted: '))
 
     return cols, rows

--- a/chart.py
+++ b/chart.py
@@ -40,7 +40,9 @@ def glucose_line_chart(recent_glucose, predicted_glucose, targets):
                 targets
             ))
 
-        for entry in predicted_glucose:
+        iter_predicted_glucose = iter(predicted_glucose)
+        next(iter_predicted_glucose)    
+        for entry in iter_predicted_glucose:
             rows.append(glucose_row(entry['date'], entry['glucose'], targets, 'Predicted: '))
 
     return cols, rows


### PR DESCRIPTION
Since the first value in predicted_glucose is identical to recent_glucose, omit it and start with the second entry; important mainly for tooltip confusion.
